### PR TITLE
fix: mel() f_min, f_max

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -5,6 +5,6 @@ and share mel spectrogram frames with the main ui thread via a Shared Array Buff
 
 It renders in real-time on an M2 Air.
 
-```
+```sh
 npm start
 ```

--- a/examples/mel_tga/README.md
+++ b/examples/mel_tga/README.md
@@ -3,7 +3,7 @@
 These spectrograms are like a photographic negative as far as Whisper is
 concerned, they can be saved, spliced and played back by whisper.cpp.
 
-```
+```sh
 cargo build && ffmpeg -hide_banner -loglevel error -i ../../testdata/JFKWHA-001-AU_WR.mp3 -f f32le -ar 16000 -acodec pcm_f32le -ac 1 pipe:1  | ./target/debug/mel_tga
 ```
 

--- a/examples/stream_whisper/README.md
+++ b/examples/stream_whisper/README.md
@@ -2,13 +2,13 @@
 
 Pipe in audio from file:
 
-```
+```sh
 ffmpeg -hide_banner -loglevel error -i ../../testdata/JFKWHA-001-AU_WR.mp3 -f f32le -ar 16000 -acodec pcm_f32le -ac 1 pipe:1  | ./target/debug/stream_whisper
 ```
 
 or microphone:
 
-```
+```sh
 ffmpeg -hide_banner -loglevel error -f avfoundation -i ":1" -f f32le -ar 16000 -acodec pcm_f32le -ac 1 pipe:1 | ./target/debug/stream_whisper
 ```
 

--- a/mel_spec/src/mel.rs
+++ b/mel_spec/src/mel.rs
@@ -1,7 +1,7 @@
 use ndarray::{s, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, Ix1};
 use num::Complex;
 
-/// MelSpectrogram applies a pre-computed filerbank to an FFT result.
+/// MelSpectrogram applies a pre-computed filterbank to an FFT result.
 /// Results are identical to whisper.cpp and whisper.py
 pub struct MelSpectrogram {
     filters: Array2<f64>,
@@ -9,7 +9,7 @@ pub struct MelSpectrogram {
 
 impl MelSpectrogram {
     pub fn new(fft_size: usize, sampling_rate: f64, n_mels: usize) -> Self {
-        let filters = mel(sampling_rate, fft_size, n_mels, false, true);
+        let filters = mel(sampling_rate, fft_size, n_mels, None, None, false, true);
         Self { filters }
     }
 
@@ -21,7 +21,7 @@ impl MelSpectrogram {
 }
 
 /// Normalisation is a separate step, see [`norm_mel`].
-/// The nomralised `Array2` output must be processed with [`interleave_frames`]
+/// The normalised `Array2` output must be processed with [`interleave_frames`]
 /// before sending to whisper.cpp
 pub fn log_mel_spectrogram(stft: &Array1<Complex<f64>>, mel_filters: &Array2<f64>) -> Array2<f64> {
     let mut magnitudes_padded = stft
@@ -70,7 +70,7 @@ pub fn norm_mel_vec(mel_spec: &[f32]) -> Vec<f32> {
     clamped
 }
 
-/// Interleave a mel spectogram
+/// Interleave a mel spectrogram
 ///
 /// Required for creating images or passing to `whisper.cpp`
 ///
@@ -302,7 +302,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fft_frequences() {
+    fn test_fft_frequencies() {
         let sr = 22050.0;
         let n_fft = 16;
 

--- a/mel_spec_pipeline/src/wasm.rs
+++ b/mel_spec_pipeline/src/wasm.rs
@@ -23,8 +23,8 @@ pub struct SpeechToMel {
 impl SpeechToMel {
     #[wasm_bindgen]
     pub fn new(fft_size: usize, hop_size: usize, sampling_rate: f64, n_mels: usize) -> Self {
-        let filters = mel(sampling_rate, fft_size, n_mels, false, true);
-        let filters2 = mel(sampling_rate, fft_size, n_mels / 4, false, true);
+        let filters = mel(sampling_rate, fft_size, n_mels, None, None, false, true);
+        let filters2 = mel(sampling_rate, fft_size, n_mels / 4, None, None, false, true);
         let stft = Spectrogram::new(fft_size, hop_size);
         let settings = DetectionSettings {
             min_energy: 1.0,


### PR DESCRIPTION
plus spelling, formatting

`cSpell` (via VS Code [	
Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) extension) flagged some spelling typos, format-on-save fixed some formatting stuff (mostly trailing spaces, plus some non-breaking spaces in code block indents, etc.), then I noticed some missing Markdown code block language identifiers, and... Here we are, a messy commit, sorry!

GitHub diff glosses over some details -- e.g. doesn't show when a space characters is actually a non-breaking space character -- so might be easier to review this in your code editor.

Happy to back out changes as desired. Or you can just reject this and make the important ones yourself.

Came here from https://github.com/RVC-Project/obs-rvc, I tried to build it locally and ran into issues.