### PR TITLE
Accept a slice in addition to a vector reference

### DIFF
--- a/mel_spec/src/quant.rs
+++ b/mel_spec/src/quant.rs
@@ -136,7 +136,7 @@ pub fn chunk_frames_into_strides(
 
 /// Quantize an interleaved spectrogram, returning u8 bytes suitable for
 /// grayscale.
-pub fn quantize(frame: &Vec<f32>) -> (Vec<u8>, QuantizationRange) {
+pub fn quantize(frame: &[f32]) -> (Vec<u8>, QuantizationRange) {
     let mut result: Vec<u8> = Vec::new();
     let min = frame.iter().copied().fold(f32::INFINITY, f32::min);
     let max = frame.iter().copied().fold(f32::NEG_INFINITY, f32::max);

--- a/mel_spec/src/stft.rs
+++ b/mel_spec/src/stft.rs
@@ -44,7 +44,7 @@ impl Spectrogram {
 
     /// Takes a single channel of audio (non-interleaved, mono, f32).
     /// Returns an FFT frame using overlap-and-save and the configured `hop_size`
-    pub fn add(&mut self, frames: &Vec<f32>) -> Option<Array1<Complex<f64>>> {
+    pub fn add(&mut self, frames: &[f32]) -> Option<Array1<Complex<f64>>> {
         let fft_size = self.fft_size;
         let hop_size = self.hop_size;
 

--- a/mel_spec/src/vad.rs
+++ b/mel_spec/src/vad.rs
@@ -252,7 +252,7 @@ impl EdgeInfo {
 /// Edge detection is overlayed in red and boundary detection in green.
 pub fn as_image(
     frames: &[Array2<f64>],
-    non_intersected_columns: &Vec<usize>,
+    non_intersected_columns: &[usize],
     gradient_positions: &HashSet<(usize, usize)>,
 ) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
     let array_views: Vec<_> = frames.iter().map(|a| a.view()).collect();


### PR DESCRIPTION
It would be useful if functions accepted a slice in addition to a vector reference.
