### PR TITLE
Use workspace dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target
 **/Cargo.lock
 .DS_Store
+mel_spec/testdata/rust_jfk.npy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,17 @@ version = "0.2.2"
 
 [workspace.dependencies]
 mel_spec = { path = "./mel_spec", version = "0.2.2" }
-mel_spec_pipeline = { path = "./mel_spec_pipeline", version = "0.2.2" }
 mel_spec_audio = { path = "./mel_spec_audio", version = "0.2.2" }
+crossbeam-channel = "0.5.8"
+image = "0.24.6"
+js-sys = "0.3.64"
+ndarray = "^0.16"
+ndarray-npy = "0.9.1"
+num = "0.4.1"
+rustfft = { version = "6.2.0" }
+soundkit = "0.10.0"
+wasm-bindgen = "0.2.87"
+web-sys = { version = "0.3.4" }
 
 [profile.release]
 codegen-units = 1

--- a/mel_spec/Cargo.toml
+++ b/mel_spec/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 [dependencies]
 image = "0.24.6"
 js-sys = "0.3.64"
-ndarray = "0.15.6"
-ndarray-npy = "0.8.1"
+ndarray = "^0.16"
+ndarray-npy = "0.9.1"
 num = "0.4.1"
 rustfft = { version = "6.2.0", features = ["wasm_simd"] }
 

--- a/mel_spec/Cargo.toml
+++ b/mel_spec/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/wavey-ai/mel-spec"
 readme = "README.md"
 
 [dependencies]
-image = "0.24.6"
-js-sys = "0.3.64"
-ndarray = "^0.16"
-ndarray-npy = "0.9.1"
-num = "0.4.1"
-rustfft = { version = "6.2.0", features = ["wasm_simd"] }
+image = { workspace = true }
+js-sys = { workspace = true }
+ndarray = { workspace = true }
+ndarray-npy = { workspace = true }
+num = { workspace = true }
+rustfft = { workspace = true, features = ["wasm_simd"] }
 
 [dev-dependencies]
-soundkit = "0.10.0"
+soundkit = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mel_spec_audio/Cargo.toml
+++ b/mel_spec_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mel_spec_audio"
-version = "0.2.2"
+version.workspace = true
 edition = "2021"
 license = "MIT"
 description = "Audio-to-Mel pipeline"
@@ -11,14 +11,9 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-js-sys = "0.3.64"
-wasm-bindgen = "0.2.87"
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
 
 [dependencies.web-sys]
-version = "0.3.4"
-features = [
-    'Worker',
-]
-
-
-
+workspace = true
+features = ['Worker']

--- a/mel_spec_pipeline/Cargo.toml
+++ b/mel_spec_pipeline/Cargo.toml
@@ -13,16 +13,14 @@ image = "0.24.6"
 js-sys = "0.3.64"
 mel_spec = { workspace = true }
 mel_spec_audio = { workspace = true }
-ndarray = "0.15.6"
+ndarray = "^0.16"
 num = "0.4.1"
 rubato = "0.14.1"
 wasm-bindgen = "0.2.87"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = [
-    'Worker',
-]
+features = ['Worker']
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mel_spec_pipeline/Cargo.toml
+++ b/mel_spec_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mel_spec_pipeline"
-version = "0.2.2"
+version.workspace = true
 edition = "2021"
 license = "MIT"
 description = "Audio-to-Mel pipeline"
@@ -8,18 +8,18 @@ repository = "https://github.com/wavey-ai/mel-spec"
 readme = "README.md"
 
 [dependencies]
-crossbeam-channel = "0.5.8"
-image = "0.24.6"
-js-sys = "0.3.64"
+crossbeam-channel = { workspace = true }
+image = { workspace = true }
+js-sys = { workspace = true }
 mel_spec = { workspace = true }
 mel_spec_audio = { workspace = true }
-ndarray = "^0.16"
-num = "0.4.1"
-rubato = "0.14.1"
-wasm-bindgen = "0.2.87"
+ndarray = { workspace = true }
+num = { workspace = true }
+rubato = { workspace = true }
+wasm-bindgen = { workspace = true }
 
 [dependencies.web-sys]
-version = "0.3.4"
+workspace = true
 features = ['Worker']
 
 [lib]


### PR DESCRIPTION
PR for #15 

- updates to ndarray version "^0.16"
- bumps ndarray-npy version
- declares all dependencies in toplevel cargo manifest

I'm noticing a few warnings about use of deprecated functions. If you want I can try to fix that in a separate PR (might have to wait a few days though)